### PR TITLE
Update minimum kind version

### DIFF
--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -80,7 +80,7 @@ func checkKindVersion() error {
 
 	userKindVersion, err := parseKindVersion(string(out))
 	if err != nil {
-		fmt.Errorf("parsing kind version: %w", err)
+		return fmt.Errorf("parsing kind version: %w", err)
 	}
 	if userKindVersion < kindVersion {
 		var resp string


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

- Updates the plugin to use a minimum kind version, rather than a specific one (i.e. version >= 0.11 vs. version == 0.11)

/kind cleanup

Fixes #92 

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

```release-note
Updates the plugin to use a minimum kind version, rather than a specific one (i.e. version >= 0.11 vs. version == 0.11)
```

/assign @csantanapr 