### PR TITLE
Cluster tests

### DIFF
--- a/test/getting-started-test.sh
+++ b/test/getting-started-test.sh
@@ -26,7 +26,7 @@ curl "$SERVICE"
 
 # Eventing Tests
 kn broker list
-echo "creating cloudevents playuer"
+echo "creating cloudevents player"
 kn service create cloudevents-player --image ruromero/cloudevents-player:latest --env BROKER_URL=http://broker-ingress.knative-eventing.svc.cluster.local/default/example-broker
 PLAYER=$(kn service describe cloudevents-player -o url)
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

Adds script for testing serving and eventing on kind and minikube locally (i.e. NOT via CI). The process for using this script is:
    * build the quickstart binary (`./hack/build.sh`)
    * run quickstart for either kind or minikube (i.e. `./kn-quickstart kind`)
    * run the script to test the  basic "getting started" knative services on the local cluster (i.e. `./test/getting-started-test.sh`)

This is a halfway step for #106; these will ultimately need to be moved to the CI, but for now it's useful for users to have some standard way to check that things are working.

/assign @csantanapr 