### PR TITLE
Joining release train

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,1 @@
 kn-quickstart*
-
-# ignore releasabilty job until on release train
-.github/workflows/knative-releasability.yaml


### PR DESCRIPTION
# Changes

As discussed in the Oct 26 DUX WG call, we're going to add the quickstart plugin onto the Knative release train. To do so, we need to re-add the releasability job back to this repo, which we'll do by undoing the changes from #102 and #121 (removing the releasability job from .gitignore so that it'll get added back by the update-actions automation job).

/assign @csantanapr 
