### PR TITLE
verify message posted in getting started test

### DIFF
--- a/test/getting-started-test.sh
+++ b/test/getting-started-test.sh
@@ -33,6 +33,8 @@ PLAYER=$(kn service describe cloudevents-player -o url)
 echo "posting event"
 curl -v "$PLAYER"   -H "Content-Type: application/json"   -H "Ce-Id: foo-1"   -H "Ce-Specversion: 1.0"   -H "Ce-Type: dev.example.events"   -H "Ce-Source: curl-source"   -d '{"msg":"Hello team!"}'
 
+curl -v "$PLAYER"/messages
+
 echo "creating trigger"
 kn trigger create cloudevents-trigger --sink cloudevents-player  --broker example-broker
 


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

# Changes

In the getting started test, check that the message was posted to the broker by curling the `/messages` endpoint

/assign @csantanapr 

