### PR TITLE
Add localhost registry to the set avoiding tag resolution as a workaround for #467

### DIFF
--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -138,7 +138,7 @@ func Serving(registries string) error {
 		if err := runCommand(ignoreRegistry); err != nil {
 			return fmt.Errorf("tag resolving configuration: %w", err)
 		}
-		fmt.Println("    Tag resolving configuration patched...")
+		fmt.Println("    Enabled local registry deployment...")
 	}
 
 	fmt.Println("    Finished installing Knative Serving")

--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -65,7 +65,14 @@ func SetUp(name, kVersion string, installServing, installEventing, installKindRe
 	}
 	if installKnative {
 		if installServing {
-			if err := install.Serving(); err != nil {
+			// Disable tag resolution for localhost registry, since there's no
+			// way to redirect Knative Serving to use the kind-registry name.
+			// See https://github.com/knative-extensions/kn-plugin-quickstart/issues/467
+			registries := ""
+			if installKindRegistry {
+				registries = fmt.Sprintf("localhost:%s", container_reg_port)
+			}
+			if err := install.Serving(registries); err != nil {
 				return fmt.Errorf("install serving: %w", err)
 			}
 			if err := install.Kourier(); err != nil {

--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -69,7 +69,7 @@ func SetUp(name, kVersion string, installServing, installEventing bool) error {
 	fmt.Scanln()
 	if installKnative {
 		if installServing {
-			if err := install.Serving(); err != nil {
+			if err := install.Serving(""); err != nil {
 				return fmt.Errorf("install serving: %w", err)
 			}
 			if err := install.Kourier(); err != nil {


### PR DESCRIPTION
# Changes

- :bug: Add default `registries-skipping-tag-resolving` setting for localhost registry when configured.  This saves a lot of debugging for new folks, since the actual registry will be reachable at `kind-registry:5000` in the containerd config, but serving doesn't have equivalent configuration.

/kind bug

Fixes #467

**Release Note**

```release-note
Automatically configure tag resolution to avoid errors when using `--registry` flag for `kn quickstart kind`.
```

**Docs**

```docs
We don't document the `--registry` flag today (though maybe we should?).
```
