### PR TITLE
Update kind/minikube/k8s versions

### DIFF
--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -26,9 +26,9 @@ import (
 	"knative.dev/kn-plugin-quickstart/pkg/install"
 )
 
-var kubernetesVersion = "kindest/node:v1.26.6"
+var kubernetesVersion = "kindest/node:v1.27.3"
 var clusterName string
-var kindVersion = 0.16
+var kindVersion = 0.20
 var container_reg_name = "kind-registry"
 var container_reg_port = "5001"
 var installKnative = true

--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -27,9 +27,9 @@ import (
 )
 
 var clusterName string
-var kubernetesVersion = "1.25.3"
+var kubernetesVersion = "1.27.3"
 var clusterVersionOverride bool
-var minikubeVersion = 1.28
+var minikubeVersion = 1.31
 var cpus = "3"
 var memory = "3072"
 var installKnative = true


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

- Updates Kubernetes version to v1.27.3
- Updates minimum kind version to v0.20
- Updates minimum minikube version to v1.31


**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Quickstart now uses Kubernetes version 1.27.3 as a default. 
The minimum recommended versions for Kind and Minikube are v0.20 and v1.31, respectively.
```

/assign @dsimansk @rhuss 