### PR TITLE
Create kind registry by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 kn-quickstart*
 .idea/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -50,13 +50,6 @@ Set up a local Knative cluster using [KinD](https://kind.sigs.k8s.io/):
 ``` bash
 kn quickstart kind
 ```
-Kind can be configured with a [local container image registry](https://kind.sigs.k8s.io/docs/user/local-registry/) by passing the `--registry` flag:
-
-```bash
-kn quickstart kind --registry
-```
-
-Note: we automatically configure tag resolution for the local registry when this flag is passed
 
 ### Quickstart with Minikube
 

--- a/internal/command/flags.go
+++ b/internal/command/flags.go
@@ -24,7 +24,6 @@ var name string
 var kubernetesVersion string
 var installServing bool
 var installEventing bool
-var installKindRegistry bool
 
 func clusterNameOption(targetCmd *cobra.Command, flagDefault string) {
 	targetCmd.Flags().StringVarP(
@@ -51,8 +50,4 @@ func installServingOption(targetCmd *cobra.Command) {
 
 func installEventingOption(targetCmd *cobra.Command) {
 	targetCmd.Flags().BoolVar(&installEventing, "install-eventing", false, "install Eventing on quickstart cluster")
-}
-
-func installKindRegistryOption(targetCmd *cobra.Command) {
-	targetCmd.Flags().BoolVar(&installKindRegistry, "registry", false, "install registry for Kind quickstart cluster")
 }

--- a/internal/command/kind.go
+++ b/internal/command/kind.go
@@ -28,7 +28,7 @@ func NewKindCommand() *cobra.Command {
 		Short: "Quickstart with Kind",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Println("Running Knative Quickstart using Kind")
-			return kind.SetUp(name, kubernetesVersion, installServing, installEventing, installKindRegistry)
+			return kind.SetUp(name, kubernetesVersion, installServing, installEventing)
 		},
 	}
 	// Set kindCmd options
@@ -36,7 +36,6 @@ func NewKindCommand() *cobra.Command {
 	kubernetesVersionOption(kindCmd, "", "kubernetes version to use (1.x.y) or (kindest/node:v1.x.y)")
 	installServingOption(kindCmd)
 	installEventingOption(kindCmd)
-	installKindRegistryOption(kindCmd)
 
 	return kindCmd
 }

--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -34,7 +34,7 @@ var container_reg_port = "5001"
 var installKnative = true
 
 // SetUp creates a local Kind cluster and installs all the relevant Knative components
-func SetUp(name, kVersion string, installServing, installEventing, installKindRegistry bool) error {
+func SetUp(name, kVersion string, installServing, installEventing bool) error {
 	start := time.Now()
 
 	// if neither the "install-serving" or "install-eventing" flags are set,
@@ -60,7 +60,7 @@ func SetUp(name, kVersion string, installServing, installEventing, installKindRe
 		}
 	}
 
-	if err := createKindCluster(installKindRegistry); err != nil {
+	if err := createKindCluster(); err != nil {
 		return fmt.Errorf("creating cluster: %w", err)
 	}
 	if installKnative {
@@ -68,10 +68,7 @@ func SetUp(name, kVersion string, installServing, installEventing, installKindRe
 			// Disable tag resolution for localhost registry, since there's no
 			// way to redirect Knative Serving to use the kind-registry name.
 			// See https://github.com/knative-extensions/kn-plugin-quickstart/issues/467
-			registries := ""
-			if installKindRegistry {
-				registries = fmt.Sprintf("localhost:%s", container_reg_port)
-			}
+			registries := fmt.Sprintf("localhost:%s", container_reg_port)
 			if err := install.Serving(registries); err != nil {
 				return fmt.Errorf("install serving: %w", err)
 			}
@@ -95,7 +92,7 @@ func SetUp(name, kVersion string, installServing, installEventing, installKindRe
 	return nil
 }
 
-func createKindCluster(registry bool) error {
+func createKindCluster() error {
 
 	if err := checkDocker(); err != nil {
 		return fmt.Errorf("%w", err)
@@ -104,16 +101,9 @@ func createKindCluster(registry bool) error {
 	if err := checkKindVersion(); err != nil {
 		return fmt.Errorf("kind version: %w", err)
 	}
-	if registry {
-		fmt.Println("💽 Installing local registry...")
-		if err := createLocalRegistry(); err != nil {
-			return fmt.Errorf("%w", err)
-		}
-	} else {
-		// temporary warning that registry creation is now opt-in
-		// remove in v1.12
-		fmt.Println("\nA local registry is no longer created by default.")
-		fmt.Println("    To create a local registry, use the --registry flag.")
+	fmt.Println("💽 Installing local registry...")
+	if err := createLocalRegistry(); err != nil {
+		return fmt.Errorf("%w", err)
 	}
 
 	if err := checkForExistingCluster(); err != nil {


### PR DESCRIPTION
Fixes knative/docs#5778

## Changes

- Upgrade _.gitignore_ with _.DS_Store_ entry
- Remove `--registry` flag
- Create local registry by default when choosing Kind