### PR TITLE
Bump minikube/kind kubernetes to v1.28

### DIFF
--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -26,7 +26,7 @@ import (
 	"knative.dev/kn-plugin-quickstart/pkg/install"
 )
 
-var kubernetesVersion = "kindest/node:v1.27.3"
+var kubernetesVersion = "kindest/node:v1.28.7"
 var clusterName string
 var kindVersion = 0.20
 var container_reg_name = "kind-registry"

--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -27,9 +27,9 @@ import (
 )
 
 var clusterName string
-var kubernetesVersion = "1.27.3"
+var kubernetesVersion = "1.28.3"
 var clusterVersionOverride bool
-var minikubeVersion = 1.31
+var minikubeVersion = 1.32
 var cpus = "3"
 var memory = "3072"
 var installKnative = true


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

Release 1.14 will require Kubernetes v1.28+
/kind cleanup



<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Minimum version of Kubernetes is v1.28
```

/assign @rhuss @dsimansk 