### PR TITLE
Kind Quickstart: Add `extraMount` Option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ kn quickstart kind --registry
 
 Note: we automatically configure tag resolution for the local registry when this flag is passed
 
+Kind can also be configured with an [extra mount](https://kind.sigs.k8s.io/docs/user/configuration#extra-mounts) so your containers can access files on your local machine.
+
+```bash
+kn quickstart kind --extraMountHostPath /home/myname/foo --extraMountContainerPath /foo
+```
+
+
 ### Quickstart with Minikube
 
 Set up a local Knative cluster using [Minikube](https://minikube.sigs.k8s.io/):

--- a/internal/command/flags.go
+++ b/internal/command/flags.go
@@ -25,6 +25,8 @@ var kubernetesVersion string
 var installServing bool
 var installEventing bool
 var installKindRegistry bool
+var installKindExtraMountHostPath string
+var installKindExtraMountContainerPath string
 
 func clusterNameOption(targetCmd *cobra.Command, flagDefault string) {
 	targetCmd.Flags().StringVarP(
@@ -55,4 +57,12 @@ func installEventingOption(targetCmd *cobra.Command) {
 
 func installKindRegistryOption(targetCmd *cobra.Command) {
 	targetCmd.Flags().BoolVar(&installKindRegistry, "registry", false, "install registry for Kind quickstart cluster")
+}
+
+func installKindExtraMountHostPathOption(targetCmd *cobra.Command) {
+	targetCmd.Flags().StringVarP(&installKindExtraMountHostPath, "extraMountHostPath", "", "", "set the extraMount hostPath on Kind quickstart cluster")
+}
+
+func installKindExtraMountContainerPathOption(targetCmd *cobra.Command) {
+	targetCmd.Flags().StringVarP(&installKindExtraMountContainerPath, "extraMountContainerPath", "", "", "set the extraMount containerPath on Kind quickstart cluster")
 }

--- a/internal/command/kind.go
+++ b/internal/command/kind.go
@@ -28,7 +28,7 @@ func NewKindCommand() *cobra.Command {
 		Short: "Quickstart with Kind",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Println("Running Knative Quickstart using Kind")
-			return kind.SetUp(name, kubernetesVersion, installServing, installEventing, installKindRegistry)
+			return kind.SetUp(name, kubernetesVersion, installServing, installEventing, installKindRegistry, installKindExtraMountHostPath, installKindExtraMountContainerPath)
 		},
 	}
 	// Set kindCmd options
@@ -37,6 +37,8 @@ func NewKindCommand() *cobra.Command {
 	installServingOption(kindCmd)
 	installEventingOption(kindCmd)
 	installKindRegistryOption(kindCmd)
+	installKindExtraMountHostPathOption(kindCmd)
+	installKindExtraMountContainerPathOption(kindCmd)
 
 	return kindCmd
 }

--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -304,6 +304,9 @@ containerdConfigPatches:
 nodes:
 - role: control-plane
   image: %s
+  extraMounts:
+  - hostPath: /home/daniel/poly/poly-alpha/server-functions
+    containerPath: /poly
   extraPortMappings:
   - containerPort: 31080
     listenAddress: 0.0.0.0

--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -299,7 +299,12 @@ func createNewCluster(extraMountHostPath string, extraMountContainerPath string)
     containerPath: %s`, extraMountHostPath, extraMountContainerPath)
 	}
 
-	fmt.Println("☸ Creating Kind cluster...")
+	if extraMount == "" {
+		fmt.Println("☸ Creating Kind cluster...")
+	} else {
+		fmt.Println("☸ Creating Kind cluster with extraMounts...")
+	}
+
 	config := fmt.Sprintf(`
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4


### PR DESCRIPTION
# Changes

Added two extra CLI arguments to `quickstart kind`:

`extraMountHostPath` and `extraMountContainerPath`.

extraMounts must be setup at the time nodes are created. So I had to change the quickstart plugin itself, rather than just applying the change after `quickstart` ran.

```bash
kn quickstart kind --registry --extraMountHostPath=/home/daniel/foo --extraMountContainerPath=/foo
```

- :gift: Add new feature

/kind enhancement

We use `kn-quickstart` as a nice way to boostrap local developers environments for testing Knative before changes go to our real Knative development server.

**Release Note**

```release-note
Added support for a Kind `extraMount` during cluster creation with the `extraMountHostPath` and `extraMountContainerPath` command line arguments.
```

**Docs**

Updated quickstart readme to document

```docs
- [Other doc]: https://github.com/eupharis/kn-plugin-quickstart?tab=readme-ov-file#quickstart-with-kind
```