### PR TITLE
Revert Camel K flag 

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 ## Getting Started
 
-Note: In order to use the `quickstart` plugin, you must install the [Kubernetes CLI `kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl) and either [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start) or [`minikube`](https://minikube.sigs.k8s.io/docs/start/). If you want to install the Apache Camel K option you also need the [`helm`](https://helm.sh/) CLI.
+Note: In order to use the `quickstart` plugin, you must install the [Kubernetes CLI `kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl) and either [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start) or [`minikube`](https://minikube.sigs.k8s.io/docs/start/).
 
 ### Installation
 

--- a/internal/command/flags.go
+++ b/internal/command/flags.go
@@ -24,7 +24,6 @@ var name string
 var kubernetesVersion string
 var installServing bool
 var installEventing bool
-var installCamel bool
 var installKindRegistry bool
 var installKindExtraMountHostPath string
 var installKindExtraMountContainerPath string
@@ -54,10 +53,6 @@ func installServingOption(targetCmd *cobra.Command) {
 
 func installEventingOption(targetCmd *cobra.Command) {
 	targetCmd.Flags().BoolVar(&installEventing, "install-eventing", false, "install Eventing on quickstart cluster")
-}
-
-func installCamelOption(targetCmd *cobra.Command) {
-	targetCmd.Flags().BoolVar(&installCamel, "install-camel", false, "install Apache Camel K on quickstart cluster")
 }
 
 func installKindRegistryOption(targetCmd *cobra.Command) {

--- a/internal/command/minikube.go
+++ b/internal/command/minikube.go
@@ -30,7 +30,7 @@ func NewMinikubeCommand() *cobra.Command {
 		Short: "Quickstart with Minikube",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Println("Running Knative Quickstart using Minikube")
-			return minikube.SetUp(name, kubernetesVersion, installServing, installEventing, installCamel)
+			return minikube.SetUp(name, kubernetesVersion, installServing, installEventing)
 		},
 	}
 	// Set minikubeCmd options
@@ -38,6 +38,5 @@ func NewMinikubeCommand() *cobra.Command {
 	kubernetesVersionOption(minikubeCmd, "", "kubernetes version to use (1.x.y)")
 	installServingOption(minikubeCmd)
 	installEventingOption(minikubeCmd)
-	installCamelOption(minikubeCmd)
 	return minikubeCmd
 }

--- a/pkg/install/install.go
+++ b/pkg/install/install.go
@@ -205,34 +205,6 @@ metadata:
 	return nil
 }
 
-func CamelK(registryAddress string) error {
-	fmt.Println("🐪 Installing Apache Camel K  ... ")
-
-	if err := addHelmRepo(); err != nil {
-		fmt.Printf("Error adding Helm repo: %v\n", err)
-		return err
-	}
-	fmt.Println("Helm repo added successfully")
-
-	// Run the Helm install command
-	if err := runHelmInstall(registryAddress); err != nil {
-		fmt.Printf("Error: %v\n", err)
-		return err
-	}
-
-	if err := waitForCRDsEstablished(); err != nil {
-		return fmt.Errorf("crds: %w", err)
-	}
-	fmt.Println("    CRDs installed...")
-
-	if err := waitForPodsReady("default"); err != nil {
-		return fmt.Errorf("core: %w", err)
-	}
-	fmt.Println("    Apache Camel K installed...")
-
-	return nil
-}
-
 func runCommand(c *exec.Cmd) error {
 	if out, err := c.CombinedOutput(); err != nil {
 		fmt.Println(string(out))
@@ -264,38 +236,4 @@ func waitForCRDsEstablished() error {
 // waitForPodsReady waits for all pods in the given namespace to be ready.
 func waitForPodsReady(ns string) error {
 	return runCommand(exec.Command("kubectl", "wait", "pod", "--timeout=10m", "--for=condition=Ready", "-l", "!job-name", "-n", ns))
-}
-
-//nolint:gosec // avoid linter warnings
-func runHelmInstall(registryAddress string) error {
-
-	// Check if helm CLI is installed
-	if _, err := exec.LookPath("helm"); err != nil {
-		return fmt.Errorf("Please install helm CLI")
-	}
-
-	cmd := exec.Command("helm", "install",
-		"--generate-name",
-		"--set", fmt.Sprintf("platform.build.registry.address=%s", registryAddress),
-		"--set", "platform.build.registry.insecure=true",
-		"camel-k/camel-k")
-
-	cmd.Stdout = cmd.Stderr
-
-	if out, err := cmd.CombinedOutput(); err != nil {
-		fmt.Println(string(out))
-		return fmt.Errorf("failed to run helm install: %w", err)
-	}
-	return nil
-}
-
-func addHelmRepo() error {
-	cmd := exec.Command("helm", "repo", "add", "camel-k", "https://apache.github.io/camel-k/charts/")
-	cmd.Stdout = cmd.Stderr
-
-	if out, err := cmd.CombinedOutput(); err != nil {
-		fmt.Println(string(out))
-		return fmt.Errorf("failed to add helm repo: %w", err)
-	}
-	return nil
 }

--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -35,7 +35,7 @@ var memory = "3072"
 var installKnative = true
 
 // SetUp creates a local Minikube cluster and installs all the relevant Knative components
-func SetUp(name, kVersion string, installServing, installEventing, installCamel bool) error {
+func SetUp(name, kVersion string, installServing, installEventing bool) error {
 	start := time.Now()
 
 	// if neither the "install-serving" or "install-eventing" flags are set,
@@ -82,19 +82,6 @@ func SetUp(name, kVersion string, installServing, installEventing, installCamel 
 		if installEventing {
 			if err := install.Eventing(); err != nil {
 				return fmt.Errorf("install eventing: %w", err)
-			}
-
-			if installCamel {
-
-				registryAddress, err := getMinikubeRegistryAddress()
-				if err != nil {
-					fmt.Printf("Error: %v\n", err)
-					return err
-				}
-
-				if err := install.CamelK(registryAddress); err != nil {
-					return fmt.Errorf("install Apache Camel K: %w", err)
-				}
 			}
 		}
 	}
@@ -283,14 +270,4 @@ func recreateCluster() error {
 		return fmt.Errorf("new cluster: %w", err)
 	}
 	return nil
-}
-
-func getMinikubeRegistryAddress() (string, error) {
-	cmd := exec.Command("kubectl", "-n", "kube-system", "get", "service", "registry", "-o", "jsonpath={.spec.clusterIP}")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		return "", fmt.Errorf("failed to get registry address: %w", err)
-	}
-	address := strings.TrimSpace(string(out))
-	return address, nil
 }


### PR DESCRIPTION
This reverts commit 136c4ab40ac5e0d6a4446816b8519a53acc1a720.

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

- :broom: Remove the Camel-K flag (was only for minikube), since w/ the Integration Source/Sink we do no longer need Apache Camel K  

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind <kind>

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note

```

**Docs**

<!--
:book: If this change has user-visible impact, link to an issue or PR in
https://github.com/knative/docs.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [knative/docs]: <issue or pr link>
- [Feature Track]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
