### PR TITLE
EN implement robust minikube with more options and networking fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 kn-quickstart*
 .idea/
+settings.json

--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ Set up a local Knative cluster using [Minikube](https://minikube.sigs.k8s.io/):
 
 ```bash
 kn quickstart minikube
+
+# OR with extra mount
+kn-quickstart minikube --extraMountHostPath /home/myname/foo --extraMountContainerPath /foo
 ```
 
 Note: for Windows/Mac users, after the above command completes, you will need to run the following in a separate terminal window:

--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ kn quickstart kind --registry
 
 Note: we automatically configure tag resolution for the local registry when this flag is passed
 
+Kind can also be configured with an [extra mount](https://kind.sigs.k8s.io/docs/user/configuration#extra-mounts) so your containers can access files on your local machine.
+
+```bash
+kn quickstart kind --extraMountHostPath /home/myname/foo --extraMountContainerPath /foo
+```
+
+
 ### Quickstart with Minikube
 
 Set up a local Knative cluster using [Minikube](https://minikube.sigs.k8s.io/):

--- a/hack/build-flags.sh
+++ b/hack/build-flags.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 # Copyright 2021 The Knative Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -24,18 +25,36 @@ function build_flags() {
     [[ -n "${commit}" ]] || (echo "error getting the current commit" && exit 1)
     version="v$(date +%Y%m%d)-local-${commit}"
   fi
-  # Knative component versions
-  local branch="`git branch --show-current | cut -d '-' -s -f2`"
-  local kourier="`git ls-remote --tags --ref https://github.com/knative-sandbox/net-kourier.git | grep -F "${branch}" | cut -d '-' -f2 | cut -d 'v' -f2 | sort -Vr | head -n 1`"
-  local eventing="`git ls-remote --tags --ref https://github.com/knative/eventing.git | grep -F "${branch}" | cut -d '-' -f2 | cut -d 'v' -f2 | sort -Vr | head -n 1`"
 
+  # Knative component versions
+  # For net-kourier:
+  local kourier="$(
+    git ls-remote --tags --refs https://github.com/knative-sandbox/net-kourier.git \
+      | awk -F'/' '{print $NF}' \
+      | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+' \
+      | sort -Vr \
+      | head -n 1 \
+      | sed 's/^v//' || echo '1.17.0'
+  )"
+
+  # For knative eventing:
+  local eventing="$(
+    git ls-remote --tags --refs https://github.com/knative/eventing.git \
+      | awk -F'/' '{print $NF}' \
+      | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+' \
+      | sort -Vr \
+      | head -n 1 \
+      | sed 's/^v//' || echo '1.17.2'
+  )"
+
+  # For knative serving:
   local serving="$(
     git ls-remote --tags --refs https://github.com/knative/serving.git \
-    | awk -F'/' '{print $NF}' \
-    | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+' \
-    | sort -Vr \
-    | head -n 1 \
-    | sed 's/^v//' || echo '1.17.0'
+      | awk -F'/' '{print $NF}' \
+      | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+' \
+      | sort -Vr \
+      | head -n 1 \
+      | sed 's/^v//' || echo '1.17.0'
   )"
 
   if [[ -z "$serving" ]]; then

--- a/hack/build-flags.sh
+++ b/hack/build-flags.sh
@@ -26,10 +26,21 @@ function build_flags() {
   fi
   # Knative component versions
   local branch="`git branch --show-current | cut -d '-' -s -f2`"
-  local serving="`git ls-remote --tags --ref https://github.com/knative/serving.git | grep -F "${branch}" | cut -d '-' -f2 | cut -d 'v' -f2 | sort -Vr | head -n 1`"
   local kourier="`git ls-remote --tags --ref https://github.com/knative-sandbox/net-kourier.git | grep -F "${branch}" | cut -d '-' -f2 | cut -d 'v' -f2 | sort -Vr | head -n 1`"
   local eventing="`git ls-remote --tags --ref https://github.com/knative/eventing.git | grep -F "${branch}" | cut -d '-' -f2 | cut -d 'v' -f2 | sort -Vr | head -n 1`"
 
+  local serving="$(
+    git ls-remote --tags --refs https://github.com/knative/serving.git \
+    | awk -F'/' '{print $NF}' \
+    | grep -Eo 'v[0-9]+\.[0-9]+\.[0-9]+' \
+    | sort -Vr \
+    | head -n 1 \
+    | sed 's/^v//' || echo '1.17.0'
+  )"
+
+  if [[ -z "$serving" ]]; then
+    serving="1.17.0"
+  fi
 
   echo "-X '${VERSION_PACKAGE}.BuildDate=${now}' -X ${VERSION_PACKAGE}.Version=${version} -X ${VERSION_PACKAGE}.GitRevision=${rev} -X ${COMPONENT_PACKAGE}.ServingVersion=${serving} -X ${COMPONENT_PACKAGE}.KourierVersion=${kourier} -X ${COMPONENT_PACKAGE}.EventingVersion=${eventing}"
 }

--- a/internal/command/flags.go
+++ b/internal/command/flags.go
@@ -25,6 +25,8 @@ var kubernetesVersion string
 var installServing bool
 var installEventing bool
 var installKindRegistry bool
+var installKindExtraMountHostPath string
+var installKindExtraMountContainerPath string
 
 func clusterNameOption(targetCmd *cobra.Command, flagDefault string) {
 	targetCmd.Flags().StringVarP(
@@ -55,4 +57,12 @@ func installEventingOption(targetCmd *cobra.Command) {
 
 func installKindRegistryOption(targetCmd *cobra.Command) {
 	targetCmd.Flags().BoolVar(&installKindRegistry, "registry", false, "install registry for Kind quickstart cluster")
+}
+
+func installKindExtraMountHostPathOption(targetCmd *cobra.Command) {
+	targetCmd.Flags().StringVarP(&installKindExtraMountHostPath, "extraMountHostPath", "", "", "set the extraMount hostPath on Kind quickstart cluster")
+}
+
+func installKindExtraMountContainerPathOption(targetCmd *cobra.Command) {
+	targetCmd.Flags().StringVarP(&installKindExtraMountContainerPath, "extraMountContainerPath", "", "", "set the extraMount containerPath on Kind quickstart cluster")
 }

--- a/internal/command/kind.go
+++ b/internal/command/kind.go
@@ -28,7 +28,7 @@ func NewKindCommand() *cobra.Command {
 		Short: "Quickstart with Kind",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Println("Running Knative Quickstart using Kind")
-			return kind.SetUp(name, kubernetesVersion, installServing, installEventing, installKindRegistry)
+			return kind.SetUp(name, kubernetesVersion, installServing, installEventing, installKindRegistry, installKindExtraMountHostPath, installKindExtraMountContainerPath)
 		},
 	}
 	// Set kindCmd options
@@ -37,6 +37,8 @@ func NewKindCommand() *cobra.Command {
 	installServingOption(kindCmd)
 	installEventingOption(kindCmd)
 	installKindRegistryOption(kindCmd)
+	installKindExtraMountHostPathOption(kindCmd)
+	installKindExtraMountContainerPathOption(kindCmd)
 
 	return kindCmd
 }

--- a/internal/command/minikube.go
+++ b/internal/command/minikube.go
@@ -53,7 +53,7 @@ func NewMinikubeCommand() *cobra.Command {
 
 	minikubeCmd.Flags().StringVar(
 		&registryPort,
-		"registry-port",
+		"registryPort",
 		"",
 		"Local registry port to expose inside Minikube",
 	)

--- a/internal/command/minikube.go
+++ b/internal/command/minikube.go
@@ -24,19 +24,51 @@ import (
 
 // NewMinikubeCommand implements 'kn quickstart minikube' command
 func NewMinikubeCommand() *cobra.Command {
+	var registryPort string
+	var extraMountHostPath string
+	var extraMountContainerPath string
 
 	var minikubeCmd = &cobra.Command{
 		Use:   "minikube",
 		Short: "Quickstart with Minikube",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			fmt.Println("Running Knative Quickstart using Minikube")
-			return minikube.SetUp(name, kubernetesVersion, installServing, installEventing)
+			return minikube.SetUp(
+				name,
+				kubernetesVersion,
+				installServing,
+				installEventing,
+				registryPort,
+				extraMountHostPath,
+				extraMountContainerPath,
+			)
 		},
 	}
-	// Set minikubeCmd options
+
+	// Existing flags
 	clusterNameOption(minikubeCmd, "knative")
 	kubernetesVersionOption(minikubeCmd, "", "kubernetes version to use (1.x.y)")
 	installServingOption(minikubeCmd)
 	installEventingOption(minikubeCmd)
+
+	minikubeCmd.Flags().StringVar(
+		&registryPort,
+		"registry-port",
+		"",
+		"Local registry port to expose inside Minikube",
+	)
+	minikubeCmd.Flags().StringVar(
+		&extraMountHostPath,
+		"extraMountHostPath",
+		"",
+		"Host path to mount into Minikube (e.g. /Users/.../server-functions)",
+	)
+	minikubeCmd.Flags().StringVar(
+		&extraMountContainerPath,
+		"extraMountContainerPath",
+		"",
+		"Container path inside Minikube for the extra mount (e.g. /poly)",
+	)
+
 	return minikubeCmd
 }

--- a/internal/command/minikube.go
+++ b/internal/command/minikube.go
@@ -67,7 +67,7 @@ func NewMinikubeCommand() *cobra.Command {
 		&extraMountContainerPath,
 		"extraMountContainerPath",
 		"",
-		"Container path inside Minikube for the extra mount (e.g. /poly)",
+		"Container path inside Minikube for the extra mount (e.g. /foo)",
 	)
 
 	return minikubeCmd

--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -304,6 +304,9 @@ containerdConfigPatches:
 nodes:
 - role: control-plane
   image: %s
+  extraMounts:
+  - hostPath: /home/daniel/poly/poly-alpha/server-functions
+    containerPath: /poly
   extraPortMappings:
   - containerPort: 31080
     listenAddress: 0.0.0.0

--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -299,7 +299,12 @@ func createNewCluster(extraMountHostPath string, extraMountContainerPath string)
     containerPath: %s`, extraMountHostPath, extraMountContainerPath)
 	}
 
-	fmt.Println("☸ Creating Kind cluster...")
+	if extraMount == "" {
+		fmt.Println("☸ Creating Kind cluster...")
+	} else {
+		fmt.Println("☸ Creating Kind cluster with extraMounts...")
+	}
+
 	config := fmt.Sprintf(`
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4

--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -21,25 +21,47 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"knative.dev/kn-plugin-quickstart/pkg/install"
 )
 
-var clusterName string
-var kubernetesVersion = "1.28.3"
-var clusterVersionOverride bool
-var minikubeVersion = 1.32
-var cpus = "3"
-var memory = "3072"
-var installKnative = true
+type MinikubeConfig struct {
+	clusterName            string
+	kubernetesVersion      string
+	clusterVersionOverride bool
+	minikubeVersion        float64
+	cpus                   string
+	memory                 string
+	installKnative         bool
+	exposeIp               string
+}
+
+var config = MinikubeConfig{
+	clusterName:            "minikube-knative",
+	kubernetesVersion:      "1.30.5",
+	clusterVersionOverride: false,
+	minikubeVersion:        1.35,
+	cpus:                   "4",
+	memory:                 "8g",
+	installKnative:         true,
+	exposeIp:               "127.0.0.1",
+}
+
+var domain = config.exposeIp + ".nip.io"
 
 // SetUp creates a local Minikube cluster and installs all the relevant Knative components
-func SetUp(name, kVersion string, installServing, installEventing bool) error {
+func SetUp(
+	name, kVersion string,
+	installServing, installEventing bool,
+	registryPort string,
+	extraMountHostPath string,
+	extraMountContainerPath string,
+) error {
 	start := time.Now()
 
-	// if neither the "install-serving" or "install-eventing" flags are set,
-	// then we assume the user wants to install both serving and eventing
+	// if neither --install-serving nor --install-eventing is set, assume both
 	if !installServing && !installEventing {
 		installServing = true
 		installEventing = true
@@ -52,74 +74,141 @@ func SetUp(name, kVersion string, installServing, installEventing bool) error {
 		os.Exit(1)
 	}
 
-	clusterName = name
+	config.clusterName = name
 	if kVersion != "" {
-		kubernetesVersion = kVersion
-		clusterVersionOverride = true
+		config.kubernetesVersion = kVersion
+		config.clusterVersionOverride = true
 	}
 
-	if err := createMinikubeCluster(); err != nil {
-		return fmt.Errorf("creating cluster: %w", err)
+	if err := createMinikubeCluster(registryPort, extraMountHostPath, extraMountContainerPath); err != nil {
+		return fmt.Errorf("❌ creating cluster: %w", err)
 	}
-	fmt.Print("\n")
-	fmt.Println("To finish setting up networking for minikube, run the following command in a separate terminal window:")
-	fmt.Println("    minikube tunnel --profile knative")
-	fmt.Println("The tunnel command must be running in a terminal window any time when using the knative quickstart environment.")
-	fmt.Println("\nPress the Enter key to continue")
+
+	fmt.Println()
+
+	if err := enableMinikubeAddon("registry"); err != nil {
+		return fmt.Errorf("❌ enabling registry addon: %w", err)
+	}
+
+	// Configure Minikube registry helper for image pushing
+	if err := setupMinikubeRegistryHelper(); err != nil {
+		return fmt.Errorf("❌ setting up registry helper: %w", err)
+	}
+	fmt.Println("✅ Minikube is now configured with registry support!")
+
+	// Pause to let the user review before continuing.
+	time.Sleep(2 * time.Second)
+	fmt.Println("\n⏎ Press the Enter key to continue")
 	fmt.Scanln()
-	if installKnative {
+
+	if config.installKnative {
 		if installServing {
 			if err := install.Serving(""); err != nil {
-				return fmt.Errorf("install serving: %w", err)
+				return fmt.Errorf("❌ install serving: %w", err)
 			}
-			if err := install.Kourier(); err != nil {
-				return fmt.Errorf("install kourier: %w", err)
-			}
-			if err := install.KourierMinikube(); err != nil {
-				return fmt.Errorf("configure kourier: %w", err)
+			if err := kourierMinikube(); err != nil {
+				return fmt.Errorf("❌ configure kourier: %w", err)
 			}
 		}
 		if installEventing {
 			if err := install.Eventing(); err != nil {
-				return fmt.Errorf("install eventing: %w", err)
+				return fmt.Errorf("❌ install eventing: %w", err)
 			}
 		}
 	}
 
+	if err := listAllPods(); err != nil {
+		fmt.Printf("Warning: could not list pods: %v\n", err)
+	}
+
+	// Start Minikube Tunnel to expose LoadBalancer
+	if err := startMinikubeTunnel(); err != nil {
+		return fmt.Errorf("❌ failed to start Minikube tunnel: %w", err)
+	}
+
+	setProfileCmd := exec.Command("minikube", "profile", config.clusterName)
+	if err := setProfileCmd.Run(); err != nil {
+		return fmt.Errorf("❌ setting minikube profile: %w", err)
+	}
+
 	finish := time.Since(start).Round(time.Second)
-	fmt.Printf("🚀 Knative install took: %s \n", finish)
+	fmt.Printf("🎯 Minikube default profile set to %s\n", config.clusterName)
+	fmt.Printf("🚀 Knative install took: %s\n", finish)
 	fmt.Println("🎉 Now have some fun with Serverless and Event Driven Apps!")
 
 	return nil
 }
 
-func createMinikubeCluster() error {
-	if err := checkMinikubeVersion(); err != nil {
-		return fmt.Errorf("minikube version: %w", err)
+func kourierMinikube() error {
+	fmt.Println("🕸  Configuring Kourier for Minikube...")
+	if err := install.RetryingApply("https://github.com/knative/net-kourier/releases/latest/download/kourier.yaml"); err != nil {
+		return fmt.Errorf("❌ default domain: %w", err)
 	}
-	if err := checkForExistingCluster(); err != nil {
-		return fmt.Errorf("existing cluster: %w", err)
+
+	fmt.Println("    Waiting for Kourier pods to be ready...")
+	if err := install.WaitForPodsReady("knative-serving"); err != nil {
+		return fmt.Errorf("❌ core: %w", err)
+	}
+
+	if err := patchKourierLoadBalancer(); err != nil {
+		return fmt.Errorf("❌ failed to patch Kourier with LoadBalancer: %w", err)
+	}
+	fmt.Println("    Kourier installation and patching complete!")
+
+	if err := install.WaitForPodsReady("knative-serving"); err != nil {
+		return fmt.Errorf("❌ core: %w", err)
+	}
+
+	if err := patchKnativeDomain(); err != nil {
+		return fmt.Errorf("❌ patching knative domain: %w", err)
+	}
+
+	if err := install.WaitForPodsReady("knative-serving"); err != nil {
+		return fmt.Errorf("❌ core: %w", err)
+	}
+
+	if err := configureKnativeIngress(); err != nil {
+		return fmt.Errorf("❌ Failed to configure Knative ingress: %w", err)
+	}
+
+	if err := install.WaitForPodsReady("knative-serving"); err != nil {
+		return fmt.Errorf("❌ core: %w", err)
+	}
+
+	fmt.Println("    Domain DNS set up...")
+	fmt.Println("    Finished configuring Kourier")
+	return nil
+}
+
+func createMinikubeCluster(
+	registryPort string,
+	extraMountHostPath string,
+	extraMountContainerPath string,
+) error {
+	if err := checkMinikubeVersion(); err != nil {
+		return fmt.Errorf("❌ minikube version: %w", err)
+	}
+	if err := checkForExistingCluster(registryPort, extraMountHostPath, extraMountContainerPath); err != nil {
+		return fmt.Errorf("❌ existing cluster: %w", err)
 	}
 	return nil
 }
 
-// checkMinikubeVersion validates that the user has the correct version of Minikube installed.
-// If not, it prompts the user to download a newer version before continuing.
 func checkMinikubeVersion() error {
 	versionCheck := exec.Command("minikube", "version", "--short")
 	out, err := versionCheck.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("minikube version: %w", err)
+		return fmt.Errorf("❌ minikube version: %w", err)
 	}
 	fmt.Printf("Minikube version is: %s\n", string(out))
 
 	userMinikubeVersion, err := parseMinikubeVersion(string(out))
 	if err != nil {
-		return fmt.Errorf("parsing minikube version: %w", err)
+		return fmt.Errorf("❌ parsing minikube version: %w", err)
 	}
-	if userMinikubeVersion < minikubeVersion {
+	if userMinikubeVersion < config.minikubeVersion {
 		var resp string
-		fmt.Printf("WARNING: We recommend at least Minikube v%.2f, while you are using v%.2f\n", minikubeVersion, userMinikubeVersion)
+		fmt.Printf("WARNING: We recommend at least Minikube v%.2f, while you are using v%.2f\n", config.minikubeVersion, userMinikubeVersion)
 		fmt.Println("You can download a newer version from https://github.com/kubernetes/minikube/releases/")
 		fmt.Print("Continue anyway? (not recommended) [y/N]: ")
 		fmt.Scanf("%s", &resp)
@@ -128,30 +217,26 @@ func checkMinikubeVersion() error {
 			os.Exit(0)
 		}
 	}
-
 	return nil
 }
 
-// checkForExistingCluster checks if the user already has a Minikube cluster. If so, it provides
-// the option of deleting the existing cluster and recreating it. If not, it proceeds to
-// creating a new cluster
-func checkForExistingCluster() error {
+func checkForExistingCluster(
+	registryPort string,
+	extraMountHostPath string,
+	extraMountContainerPath string,
+) error {
 	getClusters := exec.Command("minikube", "profile", "list")
 	out, err := getClusters.CombinedOutput()
 	if err != nil {
-		// there are no existing minikube profiles, the listing profiles command will error
-		// if there were no profiles, we simply want to create a new one and not stop the install
-		// so if the error is the "MK_USAGE_NO_PROFILE" error, we ignore it and continue onwards
 		if !strings.Contains(string(out), "MK_USAGE_NO_PROFILE") {
-			return fmt.Errorf("check cluster: %w", err)
+			return fmt.Errorf("❌ check cluster: %w", err)
 		}
 	}
-	// TODO Add tests for regex
-	r := regexp.MustCompile(clusterName)
+	r := regexp.MustCompile(config.clusterName)
 	matches := r.Match(out)
 	if matches {
 		var resp string
-		fmt.Print("Knative Cluster " + clusterName + " already installed.\nDelete and recreate [y/N]: ")
+		fmt.Printf("⚠️ Knative Cluster %s already installed.\nDelete and recreate [y/N]: ", config.clusterName)
 		fmt.Scanf("%s", &resp)
 		if strings.ToLower(resp) != "y" {
 			fmt.Println("Installation skipped")
@@ -160,82 +245,111 @@ func checkForExistingCluster() error {
 			namespaces := string(output)
 			if err != nil {
 				fmt.Println(string(output))
-				return fmt.Errorf("check existing cluster: %w", err)
+				return fmt.Errorf("❌ check existing cluster: %w", err)
 			}
 			if strings.Contains(namespaces, "knative") {
-				fmt.Print("Knative installation already exists.\nDelete and recreate the cluster [y/N]: ")
+				fmt.Print("⚠️ Knative installation already exists.\nDelete and recreate the cluster [y/N]: ")
 				fmt.Scanf("%s", &resp)
 				if strings.ToLower(resp) != "y" {
 					fmt.Println("Skipping installation")
-					installKnative = false
+					config.installKnative = false
 					return nil
 				} else {
-					if err := recreateCluster(); err != nil {
-						return fmt.Errorf("failed recreating cluster: %w", err)
-					}
+					return recreateCluster(registryPort, extraMountHostPath, extraMountContainerPath)
 				}
 			}
 			return nil
 		}
-		if err := recreateCluster(); err != nil {
-			return fmt.Errorf("failed recreating cluster: %w", err)
-		}
-		return nil
+		return recreateCluster(registryPort, extraMountHostPath, extraMountContainerPath)
 	}
-
-	if err := createNewCluster(); err != nil {
-		return fmt.Errorf("new cluster: %w", err)
-	}
-
-	return nil
+	return createNewCluster(registryPort, extraMountHostPath, extraMountContainerPath)
 }
 
-// createNewCluster creates a new Minikube cluster
-func createNewCluster() error {
+func createNewCluster(
+	registryPort string,
+	extraMountHostPath string,
+	extraMountContainerPath string,
+) error {
 	fmt.Println("☸ Creating Minikube cluster...")
 
-	if !clusterVersionOverride {
-		fmt.Println("\nUsing the standard minikube driver for your system")
-		fmt.Println("If you wish to use a different driver, please configure minikube using")
-		fmt.Print("    minikube config set driver <your-driver>\n\n")
-
-		// If minikube config kubernetes-version exists, use that instead of our default
-		if config, ok := getMinikubeConfig("kubernetes-version"); ok {
-			kubernetesVersion = config
+	if !config.clusterVersionOverride {
+		if kVersion, ok := getMinikubeConfig("kubernetes-version"); ok {
+			config.kubernetesVersion = kVersion
 		}
 	}
 
-	// get user configs for memory/cpus if they exist
-	if config, ok := getMinikubeConfig("cpus"); ok {
-		cpus = config
+	// Get user configs for memory/cpus if they exist.
+	if cpus, ok := getMinikubeConfig("cpus"); ok {
+		config.cpus = cpus
 	}
-	if config, ok := getMinikubeConfig("memory"); ok {
-		memory = config
+	if memory, ok := getMinikubeConfig("memory"); ok {
+		config.memory = memory
 	}
 
-	// create cluster and wait until ready
-	createCluster := exec.Command("minikube", "start",
-		"--kubernetes-version", kubernetesVersion,
-		"--cpus", cpus,
-		"--memory", memory,
-		"--profile", clusterName,
+	fmt.Println("ℹ️  Using the Docker minikube driver")
+	fmt.Println("If you wish to use a different driver, please configure minikube using")
+	fmt.Println("    minikube config set driver <your-driver>")
+	fmt.Println()
+
+	createClusterCmd := exec.Command(
+		"minikube", "start",
+		"--kubernetes-version", config.kubernetesVersion,
+		"--driver", "docker", // using the Docker driver as default
+		"--apiserver-ips", config.exposeIp,
+		"--cpus", config.cpus,
+		"--memory", config.memory,
+		"--profile", config.clusterName,
 		"--wait", "all",
 		"--insecure-registry", "10.0.0.0/24",
-		"--addons=registry")
-	if err := runCommandWithOutput(createCluster); err != nil {
-		return fmt.Errorf("minikube create: %w", err)
+		"--cache-images=false",
+		"--extra-config=apiserver.service-node-port-range=1-65535",
+	)
+
+	if registryPort != "" {
+		createClusterCmd.Args = append(
+			createClusterCmd.Args,
+			"--ports="+registryPort+":"+registryPort,
+		)
+	}
+
+	// If extra mount paths are specified, pass them to minikube.
+	if extraMountHostPath != "" && extraMountContainerPath != "" {
+		createClusterCmd.Args = append(
+			createClusterCmd.Args,
+			"--mount",
+			"--mount-string="+extraMountHostPath+":"+extraMountContainerPath,
+		)
+	}
+
+	fmt.Println("Creating Minikube cluster with the following options:")
+	fmt.Printf("  Default Profile: %s\n", config.clusterName)
+	fmt.Printf("  Kubernetes version: %s\n", config.kubernetesVersion)
+	fmt.Printf("  Driver: Docker\n")
+	fmt.Printf("  CPUs: %s\n", config.cpus)
+	fmt.Printf("  Memory: %s\n", config.memory)
+	fmt.Printf("  Knative domain: %s\n", domain)
+	fmt.Println()
+
+	if err := runCommandWithOutput(createClusterCmd); err != nil {
+		return fmt.Errorf("❌ minikube create: %w", err)
 	}
 
 	return nil
 }
 
-func runCommandWithOutput(c *exec.Cmd) error {
-	c.Stdout = os.Stdout
-	c.Stderr = os.Stderr
-	if err := c.Run(); err != nil {
-		return fmt.Errorf("piping output: %w", err)
+func recreateCluster(
+	registryPort string,
+	extraMountHostPath string,
+	extraMountContainerPath string,
+) error {
+	fmt.Println("🗑️  deleting cluster...")
+	deleteCluster := exec.Command("minikube", "delete", "--profile", config.clusterName)
+	if err := deleteCluster.Run(); err != nil {
+		return fmt.Errorf("❌ delete cluster: %w", err)
 	}
-	fmt.Print("\n")
+	if err := createNewCluster(registryPort, extraMountHostPath, extraMountContainerPath); err != nil {
+		return fmt.Errorf("❌ new cluster: %w", err)
+	}
 	return nil
 }
 
@@ -246,28 +360,192 @@ func parseMinikubeVersion(v string) (float64, error) {
 	if err != nil {
 		return 0, err
 	}
-
 	return floatVersion, nil
 }
 
 func getMinikubeConfig(k string) (string, bool) {
-	var ok bool
 	getConfig := exec.Command("minikube", "config", "get", k)
 	v, err := getConfig.Output()
 	if err == nil {
-		ok = true
+		return strings.TrimRight(string(v), "\n"), true
 	}
-	return strings.TrimRight(string(v), "\n"), ok
+	return "", false
 }
 
-func recreateCluster() error {
-	fmt.Println("deleting cluster...")
-	deleteCluster := exec.Command("minikube", "delete", "--profile", clusterName)
-	if err := deleteCluster.Run(); err != nil {
-		return fmt.Errorf("delete cluster: %w", err)
+func runCommandWithOutput(c *exec.Cmd) error {
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	if err := c.Run(); err != nil {
+		return fmt.Errorf("❌ piping output: %w", err)
 	}
-	if err := createNewCluster(); err != nil {
-		return fmt.Errorf("new cluster: %w", err)
+	fmt.Println()
+	return nil
+}
+
+func setupMinikubeRegistryHelper() error {
+	fmt.Println("🔄 Configuring Minikube registry helper...")
+
+	// Set Minikube's internal registry as the Docker environment.
+	cmd := exec.Command("minikube", "-p", config.clusterName, "docker-env")
+	output, err := cmd.Output()
+	if err != nil {
+		return fmt.Errorf("❌ retrieving minikube docker-env: %w", err)
 	}
+
+	// Apply the environment variables.
+	envVars := strings.Split(string(output), "\n")
+	for _, line := range envVars {
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) == 2 {
+			key := strings.TrimSpace(parts[0])
+			value := strings.Trim(parts[1], `"`)
+			os.Setenv(key, value)
+		}
+	}
+
+	return nil
+}
+
+func enableMinikubeAddon(addon string) error {
+	cmd := exec.Command("minikube", "addons", "enable", addon, "--profile", config.clusterName)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func retryCommand(cmd *exec.Cmd, maxRetries int, delay time.Duration) error {
+	var err error
+	for i := 0; i < maxRetries; i++ {
+		output, err := cmd.CombinedOutput()
+		if err == nil {
+			return nil
+		}
+		fmt.Printf("❌ Retry %d/%d failed: %s\n", i+1, maxRetries, strings.TrimSpace(string(output)))
+		time.Sleep(delay)
+	}
+	return err
+}
+
+func patchKnativeDomain() error {
+	fmt.Printf("🩹 Patching Knative config-domain\n")
+	domainPatch := fmt.Sprintf(`{"data": {"%s": ""}}`, domain)
+
+	cmd := exec.Command("kubectl", "get", "pods", "-n", "knative-serving",
+		"-l", "app=webhook",
+		"-o", "jsonpath={.items[0].status.phase}")
+
+	if err := retryCommand(cmd, 10, 5*time.Second); err != nil {
+		return fmt.Errorf("❌ webhook pod not ready after several retries: %w", err)
+	}
+
+	fmt.Println("    Webhook pod is running, proceeding with patch...")
+
+	patchCmd := exec.Command("kubectl", "patch", "configmap", "config-domain", "-n", "knative-serving",
+		"--type=merge", "-p", domainPatch)
+
+	if err := retryCommand(patchCmd, 3, 10*time.Second); err != nil {
+		return fmt.Errorf("❌ patching config-domain failed after retries: %w", err)
+	}
+
+	fmt.Printf("    Configured Knative domain to use %s\n", domain)
+	return nil
+}
+
+func listAllPods() error {
+	cmd := exec.Command("minikube", "--profile", config.clusterName, "kubectl", "--", "get", "pods", "-A")
+
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("❌ error executing 'minikube kubectl -- get pods -A': %w\nOutput: %s", err, output)
+	}
+
+	fmt.Printf("📦 All pods in %s:\n", config.clusterName)
+	outputLines := strings.Split(string(output), "\n")
+	for _, line := range outputLines {
+		fmt.Printf("    %s\n", line)
+	}
+	return nil
+}
+
+func patchKourierLoadBalancer() error {
+	fmt.Println("⚖️ Ensure Kourier is using LoadBalancer...")
+
+	getTypeCmd := exec.Command("kubectl", "get", "svc", "kourier", "-n", "kourier-system",
+		"-o", "jsonpath={.spec.type}")
+
+	serviceTypeBytes, err := getTypeCmd.Output()
+	if err != nil {
+		return fmt.Errorf("❌ failed to get Kourier service type: %w", err)
+	}
+
+	serviceType := strings.TrimSpace(string(serviceTypeBytes))
+
+	if serviceType == "LoadBalancer" {
+		fmt.Println("    Kourier is already set to LoadBalancer. No patching needed.")
+		return nil
+	}
+
+	fmt.Println("    Patching Kourier service to LoadBalancer...")
+	patchCmd := exec.Command("kubectl", "patch", "svc", "kourier", "-n", "kourier-system",
+		"--type=merge", "-p", `{"spec": {"type": "LoadBalancer"}}`)
+
+	if err := retryCommand(patchCmd, 3, 10*time.Second); err != nil {
+		return fmt.Errorf("❌ failed to patch Kourier service after retries: %w", err)
+	}
+
+	fmt.Println("    Kourier service is using LoadBalancer.")
+	return nil
+}
+
+func startMinikubeTunnel() error {
+	fmt.Println("🚇 Setup Minikube tunnel in the background to expose LoadBalancer services...")
+
+	// Find existing Minikube tunnel process
+	checkCmd := exec.Command("pgrep", "-f", "minikube tunnel")
+	_, err := checkCmd.Output()
+	if err == nil {
+		fmt.Println("    🛑 Existing Minikube tunnel found, stopping it...")
+		killCmd := exec.Command("pkill", "-f", "minikube tunnel")
+		if err := killCmd.Run(); err != nil {
+			return fmt.Errorf("❌ Failed to stop existing Minikube tunnel: %w", err)
+		}
+		time.Sleep(2 * time.Second)
+	}
+
+	fmt.Println("    🟢 Starting Minikube tunnel in the background...")
+
+	// Use `nohup` to ensure it runs persistently, with `sudo` for permissions
+	tunnelCmd := exec.Command("nohup", "sudo", "minikube", "tunnel", "-p", config.clusterName)
+	tunnelCmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true} // Detach from parent
+	tunnelCmd.Stdout = nil
+	tunnelCmd.Stderr = nil
+
+	if err := tunnelCmd.Start(); err != nil {
+		return fmt.Errorf("❌ Failed to start Minikube tunnel: %w", err)
+	}
+
+	fmt.Println("    ✅ Minikube tunnel is now running in the background.")
+	return nil
+}
+
+func configureKnativeIngress() error {
+	fmt.Println("🔄 Configuring Knative to use Kourier as the only ingress class...")
+
+	fmt.Println("    🚨 Removing existing config-network ConfigMap to enforce Kourier...")
+
+	deleteCmd := exec.Command("kubectl", "delete", "cm", "config-network", "-n", "knative-serving")
+	if err := retryCommand(deleteCmd, 3, 10*time.Second); err != nil {
+		fmt.Printf("⚠️ Warning: Could not delete config-network (may not exist yet): %v\n", err)
+	}
+
+	fmt.Println("    🗑️  ConfigMap deleted. Now recreating with Kourier as the only ingress class...")
+	createCmd := exec.Command("kubectl", "create", "configmap", "config-network", "-n", "knative-serving",
+		"--from-literal=ingress-class=kourier.ingress.networking.knative.dev")
+	if err := retryCommand(createCmd, 3, 10*time.Second); err != nil {
+		return fmt.Errorf("❌ Failed to create config-network ConfigMap after retries: %w", err)
+	}
+
+	fmt.Println("    ✅ Knative is now using Kourier as the only ingress class.")
+
 	return nil
 }


### PR DESCRIPTION
# Changes
Added new support for Minikube!
- New flags for setup command
  - registryPort
  - extraMountHostPath
  - extraMountContainerPath
- Sets Knative domain 127.0.0.1.nip.io for host machine access
- Uses Docker driver by default
- Enables registry addon and registry support
- Auto runs Minikube tunnel in the background
- Sets clusterName as the default Minikube profile
- Ensures Kourier uses LoadBalancer 

Fixes #
- Fixes bug with ingress class - now correctly installs Kourier
  - removes: `ingress-class: istio.ingress.networking.knative.dev`
  - adds: `ingress-class: kourier.ingress.networking.knative.dev`