### PR TITLE
bump kubernetes to v1.31

### DIFF
--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -33,9 +33,9 @@ import (
 	"knative.dev/kn-plugin-quickstart/pkg/install"
 )
 
-var kubernetesVersion = "kindest/node:v1.30.0"
+var kubernetesVersion = "kindest/node:v1.31.6"
 var clusterName string
-var kindVersion = 0.23
+var kindVersion = 0.26
 var container_reg_name = "kind-registry"
 var container_reg_port = "5001"
 var installKnative = true

--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -27,9 +27,9 @@ import (
 )
 
 var clusterName string
-var kubernetesVersion = "1.30.0"
+var kubernetesVersion = "1.31.6"
 var clusterVersionOverride bool
-var minikubeVersion = 1.33
+var minikubeVersion = 1.34
 var cpus = "3"
 var memory = "3072"
 var installKnative = true


### PR DESCRIPTION
# Changes

Updates default Kubernetes version to v1.31.6. Also updates the minimum recommended versions of kind and minikube.


**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Default Kubernetes version is now v1.31.6
```

cc @knative-extensions/client-writers 