### PR TITLE
Fix: update minimum k8 version to fix timeouts, add versions to documentation and fix broken link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,11 @@
 
 ## Getting Started
 
-Note: In order to use the `quickstart` plugin, you must install the [Kubernetes CLI `kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl) and either [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start) or [`minikube`](https://minikube.sigs.k8s.io/docs/start/).
+In order to use the `quickstart` plugin, you must install:
+
+* [Kubernetes CLI `kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl) (1.32.0 or later).
+* [`kind`](https://kind.sigs.k8s.io/docs/user/quick-start) (0.26 or later).
+* Or [`minikube`](https://minikube.sigs.k8s.io/docs/start/) (1.35 or later).
 
 ### Installation
 
@@ -16,15 +20,15 @@ There are two ways to run `kn quickstart`:
 
 1. You can run it standalone, just put it on your system path and make sure it is executable.
 2. You can install it as a plugin of the `kn` client to run:
-    * Follow the [documentation](https://github.com/knative/client/blob/main/docs/README.md#installing-kn) to install `kn client` if you don't have it
-    * Copy the `kn-quickstart` binary to a directory on your `PATH` (for example, `/usr/local/bin`) and make sure its filename is `kn-quickstart`
-    * Run `kn plugin list` to verify that the `kn-quickstart` plugin is installed successfully
+    * Follow the [documentation](https://github.com/knative/client/blob/main/docs/README.md#installing-kn) to install `kn client` if you don't have it.
+    * Copy the `kn-quickstart` binary to a directory on your `PATH` (for example, `/usr/local/bin`) and make sure its filename is `kn-quickstart`.
+    * Run `kn plugin list` to verify that the `kn-quickstart` plugin is installed successfully.
 
 After the plugin is installed, you can use `kn quickstart` to run its related subcommands.
 
 ## Usage
 
-```
+```txt
 Get up and running with a local Knative environment
 
 Usage:
@@ -47,7 +51,7 @@ Use "kn-quickstart [command] --help" for more information about a command.
 
 Set up a local Knative cluster using [KinD](https://kind.sigs.k8s.io/):
 
-``` bash
+```bash
 kn quickstart kind
 ```
 
@@ -58,7 +62,6 @@ Kind can also be configured with an [extra mount](https://kind.sigs.k8s.io/docs/
 ```bash
 kn quickstart kind --extraMountHostPath /home/myname/foo --extraMountContainerPath /foo
 ```
-
 
 ### Quickstart with Minikube
 
@@ -76,7 +79,7 @@ minikube tunnel --profile minikube-knative
 
 ## Building from Source
 
-You must [set up your development environment](https://github.com/knative/client/blob/master/docs/DEVELOPMENT.md#prerequisites) before you build `kn-plugin-quickstart`.
+You must [set up your development environment](https://github.com/knative/client/blob/main/DEVELOPMENT.md#prerequisites) before you build `kn-plugin-quickstart`.
 
 Once you've set up your development environment, you can build the plugin by running the following commands:
 
@@ -112,9 +115,8 @@ docker push localhost:5001/helloworld-go:latest
 
 You can grab the latest nightly binary executable for:
 
-- [macOS](https://storage.googleapis.com/knative-nightly/kn-plugin-quickstart/latest/kn-quickstart-darwin-amd64)
-- [Linux](https://storage.googleapis.com/knative-nightly/kn-plugin-quickstart/latest/kn-quickstart-linux-amd64)
-- [Windows](https://storage.googleapis.com/knative-nightly/kn-plugin-quickstart/latest/kn-quickstart-windows-amd64.exe)
+* [macOS](https://storage.googleapis.com/knative-nightly/kn-plugin-quickstart/latest/kn-quickstart-darwin-amd64)
+* [Linux](https://storage.googleapis.com/knative-nightly/kn-plugin-quickstart/latest/kn-quickstart-linux-amd64)
+* [Windows](https://storage.googleapis.com/knative-nightly/kn-plugin-quickstart/latest/kn-quickstart-windows-amd64.exe)
 
 Add the binary to the system PATH and ensure that it is executable.
-

--- a/pkg/kind/kind.go
+++ b/pkg/kind/kind.go
@@ -33,7 +33,13 @@ import (
 	"knative.dev/kn-plugin-quickstart/pkg/install"
 )
 
-var kubernetesVersion = "kindest/node:v1.31.6"
+// NOTE: If you are changing kubernetesVersion and kindVersion, please also
+// update the kubectl and kind versions listed here:
+// https://github.com/knative-extensions/kn-plugin-quickstart/blob/main/README.md
+//
+// NOTE: Latest minimum k8 version needed for knative can be found here:
+// https://github.com/knative/pkg/blob/main/version/version.go#L36
+var kubernetesVersion = "kindest/node:v1.32.0"
 var clusterName string
 var kindVersion = 0.26
 var container_reg_name = "kind-registry"

--- a/pkg/minikube/minikube.go
+++ b/pkg/minikube/minikube.go
@@ -26,10 +26,16 @@ import (
 	"knative.dev/kn-plugin-quickstart/pkg/install"
 )
 
+// NOTE: If you are changing kubernetesVersion and kindVersion, please also
+// update the kubectl and kind versions listed here:
+// https://github.com/knative-extensions/kn-plugin-quickstart/blob/main/README.md
+//
+// NOTE: Latest minimum k8 version needed for knative can be found here:
+// https://github.com/knative/pkg/blob/main/version/version.go#L36
+var kubernetesVersion = "1.32.0"
 var clusterName string
-var kubernetesVersion = "1.31.6"
 var clusterVersionOverride bool
-var minikubeVersion = 1.34
+var minikubeVersion = 1.35
 var cpus = "3"
 var memory = "3072"
 var installKnative = true


### PR DESCRIPTION
<!-- Thanks for sending a pull request! -->

<!-- 
Are you using Knative? If you do, we would love to know!
https://github.com/knative/community/issues/new?template=ADOPTERS.yaml&title=%5BADOPTERS%5D%3A+%24%7BCOMPANY+NAME+HERE%7D
-->

# Changes

<!-- 
Describe your changes here- ideally you can get that description straight from
your descriptive commit message(s)! 

- :gift: Add new feature
- :bug: Fix bug
- :broom: Update or clean up current behavior
- :wastebasket: Remove feature or internal logic
-->

The default minimum k8 version for knative changed and is listed here: https://github.com/knative/pkg/blob/main/version/version.go#L36.

- Update Kubernetes version to v1.32.0.
- Update minimum minikube version to v1.35.
- Add comment with link to default minimum kubernetes version needed by knative.
- Fix broken link in docs.
- Add versions of kubectl, kind and minikube to `README.md`.

<!--
In addition, categorize the changes you're making using the "/kind" Prow command, example:

/kind <kind>

Supported kinds are: api-change, bug, cleanup, deprecation, removal, documentation, enhancement, performance

-->
/kind bug
/kind documentation

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #601.
Fixes #600.

<!-- Please include the 'why' behind your changes if no issue exists -->

**Release Note**

<!--
:page_facing_up: If this change has user-visible impact, write a release note in the block
below. Include the string "action required" if additional action is required of
users switching to the new release, for example in case of a breaking change.

Write as if you are speaking to users, not other Knative contributors. If this
change has no user-visible impact, no release-note is needed.
-->
```release-note
Quickstart now uses Kubernetes version 1.32.0 as a default. 
The minimum recommended versions for Minikube is v1.35.
Documentation is updated to contain kubectl, kind and minikube versions.
```

